### PR TITLE
add coverage report to unit tests

### DIFF
--- a/controllers/recipes_controller.js
+++ b/controllers/recipes_controller.js
@@ -64,7 +64,7 @@ module.exports = {
       { name: 'kg', regex: /[Kk]g[s]?[.]?\s/ },
       { name: 'kg', regex: /kilogram[s]?/ },
       { name: 'kg', regex: /kilo[s]?/ },
-      { name: 'g', regex: /g[r]?[s]?[.]?\s/ },
+      { name: 'g', regex: /([0-9]|[\xbc\xbd\xbe])+\s?g[r]?[s]?[.]?\s/, findUnitRegex: /g[r]?[s]?[.]?\s/ },
       { name: 'g', regex: /gram[s]?/ },
       { name: 'ml', regex: /m[Ll][s]?[.]?/ },
       { name: 'ml', regex: /milliliter[s]?/ },
@@ -102,7 +102,7 @@ module.exports = {
 
         if (quantity.indexOf('½') > -1 || quantity.indexOf('¼') > -1 || quantity.indexOf('¾') > -1 || !isNaN(parseInt(quantity))) {
           formattedIngredients.push({ quantity, name })
-        } else if (isNaN(parseInt(quantity))) {
+        } else {
           // Quantity is not a number so this is an ingredient without quantity - For example: a handful of peanuts
           name = ingredient
           formattedIngredients.push({ name })

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
-    "test": "standard && mocha --recursive --exit"
+    "test": "standard && nyc mocha --recursive --exit"
   },
   "repository": {
     "type": "git",
@@ -18,23 +18,32 @@
   },
   "homepage": "https://github.com/ainhoaL/sugar-salt-butter#readme",
   "dependencies": {
-    "body-parser": "^1.18.2",
-    "express": "^4.16.3",
-    "mocha": "^5.1.1",
-    "mongoose": "^5.4.10",
-    "sinon": "^5.0.10",
-    "supertest": "^3.0.0"
+    "body-parser": "^1.19.0",
+    "express": "^4.16.4",
+    "mocha": "^5.2.0",
+    "mongoose": "^5.5.5",
+    "sinon": "^5.1.1",
+    "supertest": "^3.4.2"
   },
   "devDependencies": {
-    "chai": "^4.1.2",
+    "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
-    "node-mocks-http": "^1.7.3",
-    "sinon-chai": "^3.1.0",
+    "node-mocks-http": "^1.7.5",
+    "nyc": "^14.1.0",
+    "sinon-chai": "^3.3.0",
     "standard": "^12.0.1"
   },
   "standard": {
     "env": [
       "mocha"
     ]
+  },
+  "nyc": {
+    "check-coverage": true,
+    "per-file": true,
+    "lines": 100,
+    "statements": 100,
+    "functions": 100,
+    "branches": 100
   }
 }

--- a/test/controllers/recipes_controller_test.js
+++ b/test/controllers/recipes_controller_test.js
@@ -537,6 +537,30 @@ describe('Recipes controller', () => {
         })
       })
     })
+
+    describe('when the recipe has ingredients without unit', () => {
+      let expectedIngredients = [{ quantity: '10', name: 'almonds' }, { quantity: '2', name: 'sprigs of thyme' }]
+
+      it('returns the correct parsed ingredients when it is formatted "Qty Ingredient"', () => {
+        let recipe = '10 almonds\n2 sprigs of thyme'
+
+        let parsedIngredients = recipesController.parseIngredients(recipe)
+        expect(parsedIngredients.length).to.equal(2)
+        expect(parsedIngredients).to.deep.equal(expectedIngredients)
+      })
+    })
+
+    describe('when the recipe has ingredients without unit or quantity', () => {
+      let expectedIngredients = [{ name: 'a handful of almonds' }, { name: 'a few sprigs of thyme' }, { name: 'salt and pepper' }]
+
+      it('returns the correct parsed ingredients when it is formatted "Qty Ingredient"', () => {
+        let recipe = 'a handful of almonds\na few sprigs of thyme\nsalt and pepper'
+
+        let parsedIngredients = recipesController.parseIngredients(recipe)
+        expect(parsedIngredients.length).to.equal(3)
+        expect(parsedIngredients).to.deep.equal(expectedIngredients)
+      })
+    })
   })
 
   describe('processRecipe', () => {


### PR DESCRIPTION
Use Istanbul and nyc to get coverage report every time tests are run.

Add extra tests for code that was not exercised.
Fix problems found with the regular expressions.

Update npm dependencies to fix security warnings.