### PR TITLE
Add endpoint to find a recipe by ID

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,5 +1,6 @@
 const express = require('express')
 const bodyParser = require('body-parser')
+const cors = require('cors')
 const mongoose = require('mongoose')
 const routes = require('./routes')
 const app = express()
@@ -7,6 +8,7 @@ const app = express()
 mongoose.Promise = global.Promise
 mongoose.connect('mongodb://localhost/ssbrecipes')
 
+app.use(cors())
 app.use(bodyParser.json())
 app.use(routes)
 

--- a/controllers/recipes_controller.js
+++ b/controllers/recipes_controller.js
@@ -24,13 +24,17 @@ module.exports = {
      */
   getRecipe (req, res) {
     if (req.params.id) {
-      Recipe.findOne({ _id: req.params.id }).then(dbRecipe => {
-        if (dbRecipe) {
-          res.send(dbRecipe)
-        } else {
-          res.sendStatus(404)
-        }
-      })
+      Recipe.findOne({ _id: req.params.id })
+        .then(dbRecipe => {
+          if (dbRecipe) {
+            res.send(dbRecipe)
+          } else {
+            res.sendStatus(404)
+          }
+        })
+        .catch((error) => {
+          return res.status(500).send(error.message) // TODO: change for custom error message
+        })
     } else {
       res.status(400).send('missing recipe id')
     }

--- a/controllers/recipes_controller.js
+++ b/controllers/recipes_controller.js
@@ -18,6 +18,25 @@ module.exports = {
   },
 
   /**
+     * Get a recipe using the recipe model
+     * @param req {request object}
+     * @param res {response object}
+     */
+  getRecipe (req, res) {
+    if (req.params.id) {
+      Recipe.findOne({ _id: req.params.id }).then(dbRecipe => {
+        if (dbRecipe) {
+          res.send(dbRecipe)
+        } else {
+          res.sendStatus(404)
+        }
+      })
+    } else {
+      res.status(400).send('missing recipe id')
+    }
+  },
+
+  /**
      * Given a multiline string with a list of ingredients it returns a standardized array of ingredients
      * It standardizes the ingredients units so all ingredients are always stored with same units for easier conversion later on
      * @param ingredientsText {string} - a multiline string with 1 ingredient per line

--- a/controllers/recipes_controller.js
+++ b/controllers/recipes_controller.js
@@ -43,10 +43,10 @@ module.exports = {
   },
 
   /**
-     * Get a recipe using the recipe model
-     * @param req {request object}
-     * @param res {response object}
-     */
+   * Get a recipe using the recipe model
+   * @param req {request object}
+   * @param res {response object}
+   */
   getRecipe (req, res) {
     if (req.params.id) {
       Recipe.findOne({ _id: req.params.id })

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -34,6 +34,36 @@ paths:
       responses:
         200:
           description: "OK - Recipe created"
+  /recipes/{id}:
+    get:
+      tags:
+      - "recipes"
+      summary: "Returns a recipe by ID"
+      description: ""
+      operationId: "getRecipe"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "path"
+        name: "id"
+        description: "Recipe ID"
+        required: true
+        type: string
+      responses:
+        200:
+          description: "OK"
+          content:
+            application/json:
+              schema:
+                $ref: '#/definitions/Recipe'
+        400:
+          description: "Bad Request - missing recipe ID"
+        404:
+          description: "Not Found"
+        500:
+          description: "Internal Server Error"
   /recipes/search:
     get:
       tags:

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "homepage": "https://github.com/ainhoaL/sugar-salt-butter#readme",
   "dependencies": {
     "body-parser": "^1.18.2",
+    "cors": "^2.8.5",
     "express": "^4.16.3",
     "mocha": "^5.1.1",
     "mongoose": "^5.4.10",

--- a/routes.js
+++ b/routes.js
@@ -4,9 +4,9 @@ const RecipesController = require('./controllers/recipes_controller')
 
 router.post('/api/v1/recipes', (req, res) => RecipesController.create(req, res))
 
-router.get('/api/v1/recipes/:id', (req, res) => RecipesController.getRecipe(req, res))
-
 // TODO: maybe move on to GraphQL once we need to do more searches and filtering ?
 router.get('/api/v1/recipes/search', (req, res) => RecipesController.find(req, res))
+
+router.get('/api/v1/recipes/:id', (req, res) => RecipesController.getRecipe(req, res))
 
 module.exports = router

--- a/routes.js
+++ b/routes.js
@@ -4,4 +4,6 @@ const RecipesController = require('./controllers/recipes_controller')
 
 router.post('/api/v1/recipes', (req, res) => RecipesController.create(req, res))
 
+router.get('/api/v1/recipes/:id', (req, res) => RecipesController.getRecipe(req, res))
+
 module.exports = router

--- a/test/controllers/recipes_controller_test.js
+++ b/test/controllers/recipes_controller_test.js
@@ -100,7 +100,7 @@ describe('Recipes controller', () => {
 
             recipesController.getRecipe(req, res)
             expect(recipeFindOneStub.callCount).to.equal(1)
-            expect(recipeFindOneStub).to.have.been.calledWith({ id: 'testId' })
+            expect(recipeFindOneStub).to.have.been.calledWith({ _id: 'testId' })
           })
         })
 
@@ -117,7 +117,7 @@ describe('Recipes controller', () => {
 
             recipesController.getRecipe(req, res)
             expect(recipeFindOneStub.callCount).to.equal(1)
-            expect(recipeFindOneStub).to.have.been.calledWith({ id: 'norecipe' })
+            expect(recipeFindOneStub).to.have.been.calledWith({ _id: 'norecipe' })
           })
         })
       })

--- a/test/controllers/recipes_controller_test.js
+++ b/test/controllers/recipes_controller_test.js
@@ -66,6 +66,77 @@ describe('Recipes controller', () => {
         })
       })
     })
+
+    describe('getRecipe', () => {
+      let recipeFindOneStub
+
+      beforeEach(() => {
+        recipeFindOneStub = sinon.stub(Recipe, 'findOne')
+      })
+
+      afterEach(() => {
+        recipeFindOneStub.restore()
+      })
+
+      describe('receives a request with an id', () => {
+        let dbRecipe = {
+          _id: 'testId',
+          userId: 'user1',
+          title: 'test cake',
+          ingredients: [{ quantity: null, unit: null, name: 'fake ingredient' }]
+        }
+
+        describe('and the recipe exists', () => {
+          it('returns the recipe', (done) => {
+            req.params = { id: 'testId' }
+
+            recipeFindOneStub.returns(Promise.resolve(dbRecipe))
+
+            res.on('end', () => {
+              expect(res._getStatusCode()).to.equal(200)
+              expect(res._getData()).to.deep.equal(dbRecipe)
+              done()
+            })
+
+            recipesController.getRecipe(req, res)
+            expect(recipeFindOneStub.callCount).to.equal(1)
+            expect(recipeFindOneStub).to.have.been.calledWith({ id: 'testId' })
+          })
+        })
+
+        describe('but the recipe does not exist', () => {
+          it('returns a 404 error', (done) => {
+            req.params = { id: 'norecipe' }
+
+            recipeFindOneStub.returns(Promise.resolve(null))
+
+            res.on('end', () => {
+              expect(res._getStatusCode()).to.equal(404)
+              done()
+            })
+
+            recipesController.getRecipe(req, res)
+            expect(recipeFindOneStub.callCount).to.equal(1)
+            expect(recipeFindOneStub).to.have.been.calledWith({ id: 'norecipe' })
+          })
+        })
+      })
+
+      describe('receives a request without id', () => {
+        it('returns a 400 error', (done) => {
+          req.params = { }
+
+          res.on('end', () => {
+            expect(res._getStatusCode()).to.equal(400)
+            expect(res._getData()).to.deep.equal('missing recipe id')
+            done()
+          })
+
+          recipesController.getRecipe(req, res)
+          expect(recipeFindOneStub.callCount).to.equal(0)
+        })
+      })
+    })
   })
 
   describe('parseIngredients', () => {

--- a/test/routes_test.js
+++ b/test/routes_test.js
@@ -10,6 +10,7 @@ let recipesController = require('../controllers/recipes_controller.js')
 
 describe('Routes', () => {
   let recipeCreateStub
+  let recipesGetStub
 
   let testRecipe = {
     userId: 'user1',
@@ -27,10 +28,12 @@ describe('Routes', () => {
     recipeCreateStub.callsFake((req, res) => {
       return res.send(dbRecipe)
     })
+    recipesGetStub = sinon.stub(recipesController, 'getRecipe')
   })
 
   afterEach(() => {
     recipeCreateStub.restore()
+    recipesGetStub.restore()
   })
 
   describe('/api/v1/recipes', () => {
@@ -43,6 +46,43 @@ describe('Routes', () => {
           expect(response.body).to.deep.equal(dbRecipe)
           done()
         })
+    })
+
+    describe('GET /:id', (done) => {
+      describe('with an existing id', () => {
+        beforeEach(() => {
+          recipesGetStub.callsFake((req, res) => {
+            return res.send(dbRecipe)
+          })
+        })
+
+        it('returns a recipe', (done) => {
+          request(app)
+            .get('/api/v1/recipes/21')
+            .expect(200)
+            .end((_, response) => {
+              expect(response.body).to.deep.equal(dbRecipe)
+              done()
+            })
+        })
+      })
+
+      describe('with an id that does not exist', () => {
+        beforeEach(() => {
+          recipesGetStub.callsFake((req, res) => {
+            return res.send(dbRecipe)
+          })
+        })
+
+        it('returns 404', (done) => {
+          request(app)
+            .get('/api/v1/recipes/33')
+            .expect(404)
+            .end(() => {
+              done()
+            })
+        })
+      })
     })
   })
 })


### PR DESCRIPTION
Use `/api/v1/recipes/:id` to retrieve a recipe by ID. Returns the document matching that ID as is in the database.