### PR TITLE
add tags route to get all tags used in recipes

### DIFF
--- a/controllers/recipes_controller.js
+++ b/controllers/recipes_controller.js
@@ -149,6 +149,24 @@ module.exports = {
   },
 
   /**
+   * Get list of tags and the number of recipes they appear in
+   * @param req {request object}
+   * @param res {response object}
+   */
+  getTags (req, res) {
+    if (!req.userId) {
+      return res.sendStatus(401) // Not authorized
+    }
+    return Recipe.aggregate([{ $match: { userId: req.userId } }, { $unwind: '$tags' }, { $group: { _id: '$tags', count: { $sum: 1 } } }, { $sort: { count: -1 } }]) // TODO: get tags per user!!!!
+      .then(tags => {
+        return res.status(200).send(tags)
+      })
+      .catch(error => {
+        return res.status(500).send(error.message) // TODO: change for custom error message
+      })
+  },
+
+  /**
    * Given a multiline string with a list of ingredients it returns a standardized array of ingredients
    * It standardizes the ingredients units so all ingredients are always stored with same units for easier conversion later on
    * It also groups ingredients by sections. A group name starts with #. Any ingredient after it will belong to that group

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -280,6 +280,20 @@ paths:
           description: Unauthorized
         "500":
           description: Internal Server Error
+  /tags:
+    get:
+      tags:
+        - tags
+      summary: Get all tags used in recipes
+      description: ""
+      operationId: getAllTags
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TagsInRecipes"
 servers:
   - url: http://localhost:3050/api
 components:
@@ -508,3 +522,16 @@ components:
         recipeServings:
           type: integer
           example: 4
+    TagsInRecipes:
+      type: array
+      items:
+            $ref: "#/components/schemas/TagWithCount"
+    TagWithCount:
+      type: object
+      properties:
+        _id:
+          type: string
+          example: vegetarian
+        count:
+          type: integer
+          example: 20

--- a/routes.js
+++ b/routes.js
@@ -10,6 +10,8 @@ router.get('/api/v1/recipes', (req, res) => RecipesController.getAll(req, res)) 
 router.get('/api/v1/recipes/:id', (req, res) => RecipesController.get(req, res))
 router.put('/api/v1/recipes/:id', (req, res) => RecipesController.update(req, res))
 
+router.get('/api/v1/tags', (req, res) => RecipesController.getTags(req, res))
+
 router.post('/api/v1/lists', (req, res) => ListsController.create(req, res))
 router.get('/api/v1/lists/:id', (req, res) => ListsController.get(req, res))
 router.get('/api/v1/lists', (req, res) => ListsController.getAll(req, res))

--- a/test/routes_test.js
+++ b/test/routes_test.js
@@ -40,7 +40,7 @@ describe('Routes', () => {
       recipesUpdateStub = sinon.stub(recipesController, 'update')
       recipesGetAllStub = sinon.stub(recipesController, 'getAll')
       recipesGetAllStub.callsFake((req, res) => {
-        return res.send(dbRecipe)
+        return res.send({ recipes: [dbRecipe], count: 1 })
       })
 
       verifyStub = sinon.stub(authentication, 'verify')
@@ -73,12 +73,12 @@ describe('Routes', () => {
       })
 
       describe('GET', (done) => {
-        it('GET finds a recipe', (done) => {
+        it('GET finds recipes', (done) => {
           request(app)
             .get('/api/v1/recipes')
             .expect(200)
             .end((error, response) => {
-              expect(response.body).to.deep.equal(dbRecipe)
+              expect(response.body).to.deep.equal({ recipes: [dbRecipe], count: 1 })
               done(error)
             })
         })
@@ -157,6 +157,48 @@ describe('Routes', () => {
                 done(error)
               })
           })
+        })
+      })
+    })
+  })
+
+  describe('tags', () => {
+    let getTagsStub
+    let verifyStub
+
+    const userId = 'user1'
+    const tagsArray = [{ _id: 'meat', count: 1 }, { _id: 'vegetarian', count: 20 }]
+
+    beforeEach(() => {
+      getTagsStub = sinon.stub(recipesController, 'getTags')
+      getTagsStub.callsFake((req, res) => {
+        return res.send(tagsArray)
+      })
+
+      verifyStub = sinon.stub(authentication, 'verify')
+      verifyStub.callsFake((req, res, next) => {
+        req.userId = userId
+        return next()
+      })
+
+      app = require('../app.js')
+    })
+
+    afterEach(() => {
+      getTagsStub.restore()
+      verifyStub.restore()
+    })
+
+    describe('/api/v1/tags', () => {
+      describe('GET', (done) => {
+        it('returns tags array', (done) => {
+          request(app)
+            .get('/api/v1/tags')
+            .expect(200)
+            .end((error, response) => {
+              expect(response.body).to.deep.equal(tagsArray)
+              done(error)
+            })
         })
       })
     })

--- a/test/utils/parsing_test.js
+++ b/test/utils/parsing_test.js
@@ -36,6 +36,9 @@ describe('parsing', () => {
       it('returns 2/3 if the value is 0.666', () => {
         expect(parsing.numberToFraction(0.666)).to.equal('2/3')
       })
+      it('returns 2/3 if the value is 0.667', () => {
+        expect(parsing.numberToFraction(0.667)).to.equal('2/3')
+      })
       it('returns 5 1/2 if the value is 5.5', () => {
         expect(parsing.numberToFraction(5.5)).to.equal('5 1/2')
       })

--- a/utils/parsing.js
+++ b/utils/parsing.js
@@ -38,6 +38,7 @@ module.exports = {
     value = Math.floor(numerator) + '/' + Math.floor(denominator)
     if (value === '333/1000') value = '1/3'
     if (value === '333/500') value = '2/3'
+    if (value === '667/1000') value = '2/3'
     if (base) {
       value = base + ' ' + value
     }


### PR DESCRIPTION
- New route GET `/tags` that returns an array with all the tags used across recipes and how may recipes they appear in (ordered by count desc):
`[{_id:'vegetarian', count:20},{_id:'vegan', count:10}]`
- Unit tests
- Updated swagger