### PR TITLE
Add routes to delete list and delete item from list

### DIFF
--- a/controllers/lists_controller.js
+++ b/controllers/lists_controller.js
@@ -174,6 +174,28 @@ module.exports = {
   },
 
   /**
+   * Delete a list using the list model
+   * @param req {request object}
+   * @param res {response object}
+   */
+  deleteList (req, res) {
+    if (!req.userId) {
+      return res.sendStatus(401) // Not authorized
+    }
+    if (req.params.id) {
+      return List.deleteOne({ _id: req.params.id, userId: req.userId })
+        .then((dbList) => {
+          return res.sendStatus(204)
+        })
+        .catch((error) => {
+          return res.status(500).send(error.message) // TODO: change for custom error message
+        })
+    } else {
+      res.status(400).send('missing list ID')
+    }
+  },
+
+  /**
    * Get all lists
    * @param req {request object}
    * @param res {response object}
@@ -216,7 +238,7 @@ module.exports = {
       return res.sendStatus(401) // Not authorized
     }
     if (req.params.id && req.params.recipeId) {
-      List.update({ _id: req.params.id, userId: req.userId }, { $pull: { items: { recipeId: { $in: [req.params.recipeId] } } } })
+      List.update({ _id: req.params.id, userId: req.userId }, { $pull: { items: { recipeId: req.params.recipeId } } })
         .then((dbList) => {
           return res.sendStatus(204)
         })
@@ -268,6 +290,28 @@ module.exports = {
         })
     } else {
       res.status(400).send('missing list ID or recipe ID')
+    }
+  },
+
+  /**
+   * Delete one item from list
+   * @param req {request object}
+   * @param res {response object}
+   */
+  deleteItemFromList (req, res) {
+    if (!req.userId) {
+      return res.sendStatus(401) // Not authorized
+    }
+    if (req.params.id && req.params.itemId) {
+      List.update({ _id: req.params.id, userId: req.userId }, { $pull: { items: { _id: req.params.itemId } } })
+        .then(() => {
+          return res.sendStatus(204)
+        })
+        .catch((error) => {
+          return res.status(500).send(error.message) // TODO: change for custom error message
+        })
+    } else {
+      return res.status(400).send('missing list ID or item ID')
     }
   }
 }

--- a/controllers/recipes_controller.js
+++ b/controllers/recipes_controller.js
@@ -34,7 +34,7 @@ module.exports = {
       return res.sendStatus(401) // Not authorized
     }
     if (req.params.id) {
-      return Recipe.deleteOne({ _id: req.params.id })
+      return Recipe.deleteOne({ _id: req.params.id, userId: req.userId })
         .then(() => {
           res.sendStatus(204)
         })
@@ -124,7 +124,7 @@ module.exports = {
       return res.sendStatus(401) // Not authorized
     }
     if (req.params.id) {
-      return Recipe.findOne({ _id: req.params.id })
+      return Recipe.findOne({ _id: req.params.id, userId: req.userId })
         .then(dbRecipe => {
           if (dbRecipe) {
             res.send(dbRecipe)
@@ -154,7 +154,7 @@ module.exports = {
       recipe = module.exports.processRecipe(recipe)
       recipe.userId = req.userId
 
-      return Recipe.replaceOne({ _id: req.params.id }, recipe)
+      return Recipe.replaceOne({ _id: req.params.id, userId: req.userId }, recipe)
         .then(dbRecipe => {
           if (dbRecipe) {
             return res.sendStatus(204)

--- a/routes.js
+++ b/routes.js
@@ -15,9 +15,10 @@ router.get('/api/v1/tags', (req, res) => RecipesController.getTags(req, res))
 
 router.post('/api/v1/lists', (req, res) => ListsController.create(req, res))
 router.get('/api/v1/lists/:id', (req, res) => ListsController.get(req, res))
+router.delete('/api/v1/lists/:id', (req, res) => ListsController.deleteList(req, res))
 router.get('/api/v1/lists', (req, res) => ListsController.getAll(req, res))
 router.post('/api/v1/lists/:id/recipes', (req, res) => ListsController.addRecipeToList(req, res))
 router.delete('/api/v1/lists/:id/recipes/:recipeId', (req, res) => ListsController.deleteRecipeFromList(req, res))
-// router.delete('/api/v1/lists/:id/items/:itemId', (req, res) => ListsController.deleteItemFromList(req, res))
+router.delete('/api/v1/lists/:id/items/:itemId', (req, res) => ListsController.deleteItemFromList(req, res))
 
 module.exports = router

--- a/test/controllers/lists_controller_test.js
+++ b/test/controllers/lists_controller_test.js
@@ -430,8 +430,8 @@ describe('Lists controller', () => {
         })
       })
 
-      describe('receives a request without userId id', () => {
-        it('returns a 400 error', (done) => {
+      describe('receives a request without userId', () => {
+        it('returns a 401 error', (done) => {
           req.params = { }
           req.userId = null
 
@@ -628,8 +628,8 @@ describe('Lists controller', () => {
         })
       })
 
-      describe('receives a request without userId id', () => {
-        it('returns a 400 error', (done) => {
+      describe('receives a request without userId', () => {
+        it('returns a 401 error', (done) => {
           req.userId = null
 
           res.on('end', () => {

--- a/test/controllers/recipes_controller_test.js
+++ b/test/controllers/recipes_controller_test.js
@@ -111,7 +111,7 @@ describe('Recipes controller', () => {
       describe('receives a request with an id', () => {
         const dbRecipe = {
           _id: 'testId',
-          userId: 'user1',
+          userId: 'testUserId',
           title: 'test cake',
           ingredients: [{ quantity: null, unit: null, name: 'fake ingredient' }]
         }
@@ -124,7 +124,7 @@ describe('Recipes controller', () => {
 
             res.on('end', () => {
               expect(recipeFindOneStub.callCount).to.equal(1)
-              expect(recipeFindOneStub).to.have.been.calledWith({ _id: 'testId' })
+              expect(recipeFindOneStub).to.have.been.calledWith({ _id: 'testId', userId: 'testUserId' })
               expect(res._getStatusCode()).to.equal(200)
               expect(res._getData()).to.deep.equal(dbRecipe)
               done()
@@ -142,7 +142,7 @@ describe('Recipes controller', () => {
 
             res.on('end', () => {
               expect(recipeFindOneStub.callCount).to.equal(1)
-              expect(recipeFindOneStub).to.have.been.calledWith({ _id: 'norecipe' })
+              expect(recipeFindOneStub).to.have.been.calledWith({ _id: 'norecipe', userId: 'testUserId' })
               expect(res._getStatusCode()).to.equal(404)
               done()
             })
@@ -159,7 +159,7 @@ describe('Recipes controller', () => {
 
             res.on('end', () => {
               expect(recipeFindOneStub.callCount).to.equal(1)
-              expect(recipeFindOneStub).to.have.been.calledWith({ _id: 'testId' })
+              expect(recipeFindOneStub).to.have.been.calledWith({ _id: 'testId', userId: 'testUserId' })
               expect(res._getStatusCode()).to.equal(500)
               expect(res._getData()).to.equal('Error searching')
               done()
@@ -214,14 +214,14 @@ describe('Recipes controller', () => {
 
       describe('receives a request with an id', () => {
         describe('and the recipe exists', () => {
-          it('returns the recipe', (done) => {
+          it('returns 204', (done) => {
             req.params = { id: 'testId' }
 
-            recipeDeleteOneStub.returns(Promise.resolve())
+            recipeDeleteOneStub.resolves()
 
             res.on('end', () => {
               expect(recipeDeleteOneStub.callCount).to.equal(1)
-              expect(recipeDeleteOneStub).to.have.been.calledWith({ _id: 'testId' })
+              expect(recipeDeleteOneStub).to.have.been.calledWith({ _id: 'testId', userId: 'testUserId' })
               expect(res._getStatusCode()).to.equal(204)
               done()
             })
@@ -238,7 +238,7 @@ describe('Recipes controller', () => {
 
             res.on('end', () => {
               expect(recipeDeleteOneStub.callCount).to.equal(1)
-              expect(recipeDeleteOneStub).to.have.been.calledWith({ _id: 'testId' })
+              expect(recipeDeleteOneStub).to.have.been.calledWith({ _id: 'testId', userId: 'testUserId' })
               expect(res._getStatusCode()).to.equal(500)
               expect(res._getData()).to.equal('Error deleting')
               done()
@@ -766,7 +766,7 @@ describe('Recipes controller', () => {
 
             res.on('end', () => {
               expect(recipeReplaceOneStub.callCount).to.equal(1)
-              expect(recipeReplaceOneStub).to.have.been.calledWith({ _id: 'testId' })
+              expect(recipeReplaceOneStub).to.have.been.calledWith({ _id: 'testId', userId: 'testUserId' })
               expect(res._getStatusCode()).to.equal(204)
               done()
             })
@@ -784,7 +784,7 @@ describe('Recipes controller', () => {
 
             res.on('end', () => {
               expect(recipeReplaceOneStub.callCount).to.equal(1)
-              expect(recipeReplaceOneStub).to.have.been.calledWith({ _id: 'norecipe' })
+              expect(recipeReplaceOneStub).to.have.been.calledWith({ _id: 'norecipe', userId: 'testUserId' })
               expect(res._getStatusCode()).to.equal(404)
               done()
             })
@@ -802,7 +802,7 @@ describe('Recipes controller', () => {
 
             res.on('end', () => {
               expect(recipeReplaceOneStub.callCount).to.equal(1)
-              expect(recipeReplaceOneStub).to.have.been.calledWith({ _id: 'testId' })
+              expect(recipeReplaceOneStub).to.have.been.calledWith({ _id: 'testId', userId: 'testUserId' })
               expect(res._getStatusCode()).to.equal(500)
               expect(res._getData()).to.equal('Error searching')
               done()

--- a/test/routes_test.js
+++ b/test/routes_test.js
@@ -228,10 +228,12 @@ describe('Routes', () => {
 
   describe('lists', () => {
     let listsGetStub
+    let listsDeleteStub
     let listsCreateStub
     let listsGetAllStub
     let addRecipeToListStub
     let deleteRecipeFromListStub
+    let deleteItemFromListStub
     let verifyStub
 
     const userId = 'user1'
@@ -263,6 +265,7 @@ describe('Routes', () => {
         return res.send(dbList)
       })
       listsGetStub = sinon.stub(listsController, 'get')
+      listsDeleteStub = sinon.stub(listsController, 'deleteList')
       listsGetAllStub = sinon.stub(listsController, 'getAll')
       listsGetAllStub.callsFake((req, res) => {
         return res.send(dbTestLists)
@@ -273,6 +276,10 @@ describe('Routes', () => {
       })
       deleteRecipeFromListStub = sinon.stub(listsController, 'deleteRecipeFromList')
       deleteRecipeFromListStub.callsFake((req, res) => {
+        return res.sendStatus(204)
+      })
+      deleteItemFromListStub = sinon.stub(listsController, 'deleteItemFromList')
+      deleteItemFromListStub.callsFake((req, res) => {
         return res.sendStatus(204)
       })
 
@@ -288,9 +295,11 @@ describe('Routes', () => {
     afterEach(() => {
       listsCreateStub.restore()
       listsGetStub.restore()
+      listsDeleteStub.restore()
       listsGetAllStub.restore()
       addRecipeToListStub.restore()
       deleteRecipeFromListStub.restore()
+      deleteItemFromListStub.restore()
       verifyStub.restore()
     })
 
@@ -352,6 +361,25 @@ describe('Routes', () => {
           })
         })
       })
+
+      describe('DELETE /:id', (done) => {
+        describe('with an existing id', () => {
+          beforeEach(() => {
+            listsDeleteStub.callsFake((req, res) => {
+              return res.sendStatus(204)
+            })
+          })
+
+          it('returns 204', (done) => {
+            request(app)
+              .delete('/api/v1/lists/21')
+              .expect(204)
+              .end((error, response) => {
+                done(error)
+              })
+          })
+        })
+      })
     })
 
     describe('/api/v1/lists/:id/recipes', () => {
@@ -368,6 +396,17 @@ describe('Routes', () => {
       it('DELETE removes a recipe from a list', (done) => {
         request(app)
           .delete('/api/v1/lists/list1/recipes/recipe1')
+          .expect(204)
+          .end((error, response) => {
+            done(error)
+          })
+      })
+    })
+
+    describe('/api/v1/lists/:id/items', () => {
+      it('DELETE removes an item from a list', (done) => {
+        request(app)
+          .delete('/api/v1/lists/list1/items/item1')
           .expect(204)
           .end((error, response) => {
             done(error)


### PR DESCRIPTION
- Add methods to list controller to delete a single list and delete a single item from a list
- Add routes for:
  - DELETE `/api/v1/lists/:id`
  - DELETE `/api/v1/lists/:id/items/:itemId`
- Fix recipe methods that didn't use the userId (they need to specify userId when making requests via mongoose)
- Unit tests